### PR TITLE
ANCS: non-outline icon for business and finance category

### DIFF
--- a/ancs.cpp
+++ b/ancs.cpp
@@ -279,7 +279,7 @@ void ANCS::decodeIcon(unsigned int categoryId, QString &result)
         break;
 
     case ANCS_CATEGORY_ID_BUSINESS_AND_FINANCE:
-        result = "ios-briefcase-outline";
+        result = "ios-briefcase";
         break;
 
     case ANCS_CATEGORY_ID_LOCATION:


### PR DESCRIPTION
The current icon (ios-briefcase-outline) is too similar to the calendar icon (ios-calendar-outline), which is somewhat confusing.