### PR TITLE
Search for ANCS characteristics when services are already resolved

### DIFF
--- a/ancs.cpp
+++ b/ancs.cpp
@@ -19,7 +19,7 @@ bool ANCS::isMatchingCharacteristic(QString uuid, QMap<QString, QVariantMap> dbu
     return charUuid.toLower() == uuid.toLower();
 }
 
-void ANCS::SearchForAncsCharacteristics()
+void ANCS::searchForAncsCharacteristics()
 {
     QDBusConnection bus = QDBusConnection::systemBus();
     QDBusInterface remoteOm(BLUEZ_SERVICE_NAME, "/", DBUS_OM_IFACE, bus);

--- a/ancs.h
+++ b/ancs.h
@@ -18,8 +18,8 @@ struct ANCSMessageCacheEntry {
 class ANCS: public QObject
 {
     Q_OBJECT
-public slots:
-    void SearchForAncsCharacteristics();
+public:
+    void searchForAncsCharacteristics();
 private slots:
     void NotificationCharacteristicPropertiesChanged( QString interfaceName,
                                                       QMap<QString, QVariant> changedProperties, QStringList invalidatedProperties);

--- a/bluezmanager.cpp
+++ b/bluezmanager.cpp
@@ -39,6 +39,7 @@ BlueZManager::BlueZManager(QDBusObjectPath appPath, QDBusObjectPath advertPath, 
 
     connect(this, SIGNAL(adapterChanged()), this, SLOT(onAdapterChanged()));
     connect(this, SIGNAL(connectedChanged()), this, SLOT(onConnectedChanged()));
+    connect(this, SIGNAL(servicesResolvedChanged()), this, SLOT(onServicesResolvedChanged()));
 
     QDBusInterface remoteOm(BLUEZ_SERVICE_NAME, "/", DBUS_OM_IFACE, mBus);
     if(remoteOm.isValid())
@@ -172,8 +173,6 @@ void BlueZManager::onConnectedChanged()
 
     if(mConnected) {
         //% "Connected"
-        // TODO: not a perfect way to discover ANCS characteristics, but good enough for now
-        QTimer::singleShot(2000, &mAncs, SLOT(SearchForAncsCharacteristics()));
         summary = qtTrId("id-connected");
         body = mConnectedDevice;
         appIcon = "ios-bluetooth-outline";
@@ -203,4 +202,9 @@ void BlueZManager::onConnectedChanged()
 
     static QDBusInterface notifyApp(NOTIFICATIONS_SERVICE_NAME, NOTIFICATIONS_PATH_BASE, NOTIFICATIONS_MAIN_IFACE);
     notifyApp.callWithArgumentList(QDBus::AutoDetect, "Notify", argumentList);
+}
+
+void BlueZManager::onServicesResolvedChanged() {
+    if (mServicesResolved)
+        mAncs.searchForAncsCharacteristics();
 }

--- a/bluezmanager.h
+++ b/bluezmanager.h
@@ -60,6 +60,7 @@ public slots:
     void PropertiesChanged(QString, QMap<QString, QVariant>, QStringList);
 
     void onConnectedChanged();
+    void onServicesResolvedChanged();
     void onAdapterChanged();
 };
 


### PR DESCRIPTION
Remove the timer hack and search for ANCS characteristics when services are resolved.