### PR TITLE
Treat compiler warnings as errors

### DIFF
--- a/asteroid-btsyncd.pro
+++ b/asteroid-btsyncd.pro
@@ -3,6 +3,7 @@ QT -= gui
 QT += dbus
 CONFIG += link_pkgconfig c++11
 PKGCONFIG += giomm-2.4 mpris-qt5 contextkit-statefs timed-qt5
+QMAKE_CXXFLAGS += -Werror
 
 HEADERS += \
     notificationservice.h \


### PR DESCRIPTION
Since there are currently no warnings in Btsyncd, it's probably a good idea to enforce that state until there is a compelling reason not to.