### PR TITLE
BatteryService: Use systemsettings for battery information.

### DIFF
--- a/asteroid-btsyncd.pro
+++ b/asteroid-btsyncd.pro
@@ -2,7 +2,7 @@ TEMPLATE = app
 QT -= gui
 QT += dbus
 CONFIG += link_pkgconfig c++11
-PKGCONFIG += giomm-2.4 mpris-qt5 contextkit-statefs timed-qt5
+PKGCONFIG += giomm-2.4 mpris-qt5 systemsettings timed-qt5
 
 HEADERS += \
     notificationservice.h \

--- a/batteryservice.cpp
+++ b/batteryservice.cpp
@@ -15,7 +15,7 @@
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
 
-#include <contextproperty.h>
+#include <batterystatus.h>
 
 #include <QTimer>
 #include <QDBusMessage>
@@ -27,19 +27,20 @@
 
 BatteryLvlChrc::BatteryLvlChrc(QDBusConnection bus, int index, Service *service) : Characteristic(bus, index, BATTERY_LVL_UUID, {"encrypt-authenticated-read", "notify"}, service)
 {
-    m_battery = new ContextProperty("Battery.ChargePercentage", this);
-    connect(m_battery, SIGNAL(valueChanged()), this, SLOT(onBatteryPercentageChanged()));
+    m_battery = new BatteryStatus(this);
+    connect(m_battery, &BatteryStatus::chargePercentageChanged,
+            this, &BatteryLvlChrc::onBatteryPercentageChanged);
     connect(this, SIGNAL(valueChanged()), this, SLOT(emitPropertiesChanged()));
     m_value = QByteArray(1, 100);
-    QTimer::singleShot(0, this, SLOT(onBatteryPercentageChanged()));
 }
 
-void BatteryLvlChrc::onBatteryPercentageChanged()
+void BatteryLvlChrc::onBatteryPercentageChanged(int percentage)
 {
-    char val = m_battery->value().toUInt();
-    m_value = QByteArray(1, val);
+    if (percentage >= 0) {
+        m_value = QByteArray(1, percentage);
 
-    emit valueChanged();
+        emit valueChanged();
+    }
 }
 
 void BatteryLvlChrc::emitPropertiesChanged()

--- a/batteryservice.h
+++ b/batteryservice.h
@@ -22,7 +22,7 @@
 
 #include "service.h"
 
-class ContextProperty;
+class BatteryStatus;
 
 class BatteryLvlChrc : public Characteristic
 {
@@ -42,13 +42,13 @@ public slots:
 
 private slots:
     void emitPropertiesChanged();
-    void onBatteryPercentageChanged();
+    void onBatteryPercentageChanged(int percentage);
 
 signals:
     void valueChanged();
 
 private:
-    ContextProperty *m_battery;
+    BatteryStatus *m_battery;
     QByteArray m_value;
 
     QByteArray getValue()


### PR DESCRIPTION
i.e. more work towards deprecating `statefs`.
This implementation is basically taken from buteo-mtp: https://git.sailfishos.org/mer-core/buteo-mtp/commit/d70475180d3b67c75f5c1fb195c926a646c02ca5

Need to do some more testing with lipstick (https://github.com/MagneFire/lipstick/commits/gatesgarth_v2), otherwise everything seems to work.
I'll add a WIP meta-asteroid PR when everything is in a more usable state.
For now the changes in meta-asteroid are:
- Remove: statefs, statefs-providers, statefs-loader-qt, nemo-qml-plugin-contextkit.
- Update: DSME, buteo-mtp, mce, mcedevel, timed, usb-moded, sensorfw (Needs work, had to revert a commit for it to work https://github.com/MagneFire/sensorfw/commits/gatesgarth_v2)
- Add: mce-qt5, sailfish-access-control (timed needs this now)