### PR TITLE
Timeservice: assume that the incoming time data is in local time

### DIFF
--- a/src/timeservice.cpp
+++ b/src/timeservice.cpp
@@ -18,6 +18,7 @@
 #include <QDBusInterface>
 #include <QDBusMessage>
 #include <QDateTime>
+#include <QTimeZone>
 
 #include <timed-qt5/wallclock>
 #include <timed-qt5/interface>
@@ -37,6 +38,7 @@ void TimeSetChrc::WriteValue(QByteArray value, QVariantMap)
 
     Maemo::Timed::WallClock::Settings s;
     QDateTime newTime(QDate(year, month, day), QTime(hour, minute, second));
+    newTime.setTimeZone(QTimeZone::systemTimeZone());
     s.setTimeManual(newTime.toTime_t());
 
     Maemo::Timed::Interface timed;


### PR DESCRIPTION
Asteroid now has a UI for setting the watch timezone. Since the paired device sends the local time to the watch, having a timezone other than UTC set and using a sync client will cause the watch to display the wrong time. This provides a fix by assuming that the incoming time is in the same timezone as the system timezone.
This is a stopgap solution until timezones are also synchronised using something more reasonable such as the BLE CTS profile.