### PR TITLE
Add notify flag to Time and Weather characteristics

### DIFF
--- a/src/timeservice.h
+++ b/src/timeservice.h
@@ -27,7 +27,7 @@ class TimeSetChrc : public Characteristic
     Q_OBJECT
 public:
     TimeSetChrc(QDBusConnection bus, int index, Service *service)
-        : Characteristic(bus, index, TIME_SET_UUID, {"encrypt-authenticated-write"}, service) {}
+        : Characteristic(bus, index, TIME_SET_UUID, {"encrypt-authenticated-write", "notify"}, service) {}
 
 public slots:
     void WriteValue(QByteArray, QVariantMap);

--- a/src/weatherservice.cpp
+++ b/src/weatherservice.cpp
@@ -29,7 +29,7 @@ int getQByteArrayInt(QByteArray arr, int index) {
 class WeatherCityChrc : public Characteristic
 {
 public:
-    WeatherCityChrc(QDBusConnection bus, int index, Service *service) : Characteristic(bus, index, WEAT_CITY_UUID, {"encrypt-authenticated-write"}, service) {}
+    WeatherCityChrc(QDBusConnection bus, int index, Service *service) : Characteristic(bus, index, WEAT_CITY_UUID, {"encrypt-authenticated-write","notify"}, service) {}
 
 public slots:
     void WriteValue(QByteArray value, QVariantMap)


### PR DESCRIPTION
Around May of 2022, when I updated from qt5-qtconnectivity-5.15.3-1.fc36.x86_64 to qt5-qtconnectivity-5.15.5-2.fc36.x86_64 there was a new problem. This fixes https://github.com/AsteroidOS/libasteroid/issues/17 but I don't know why.

Simply adding a "notify" flag to one arbitrarily chosen characteristic from each of the failing services restored correct operation with asteroid-ctrl and libasteroid.