### PR TITLE
Only update paired BT name for connected device

### DIFF
--- a/src/bluezmanager.cpp
+++ b/src/bluezmanager.cpp
@@ -101,14 +101,16 @@ void BlueZManager::updateAdapter() {
             if (value.contains(DEVICE_MANAGER_IFACE)) {
                  mBus.connect(BLUEZ_SERVICE_NAME, key, DBUS_PROPERTIES_IFACE, "PropertiesChanged", this, SLOT(PropertiesChanged(QString, QMap<QString, QVariant>, QStringList)));
                  QMap<QString, QVariant> properties = value.value(DEVICE_MANAGER_IFACE);
-                 if(properties.contains("Connected"))
-                    connected |= properties.value("Connected").toBool();
+                 if(properties.contains("Connected") && properties.value("Connected").toBool()) {
+                    connected = true;
+                    if(properties.contains("Alias")) {
+                       mConnectedDevice = properties.value("Alias").toString();
+                    }
+                 }
 
                  if(properties.contains("ServicesResolved"))
                     servicesResolved |= properties.value("ServicesResolved").toBool();
 
-                 if(properties.contains("Alias"))
-                    mConnectedDevice = properties.value("Alias").toString();;
             }
         }
         argument.endMap();


### PR DESCRIPTION
When one changes the device that is connected to an AsteroidOS watch, what should happen is that the name of the new device should be shown in the "Connected" message.  What was actually happening was that it would show the first device name instead.  This corrects that behavior to only update the name if the particular listed D-Bus device is also connected.  This fixes issue #33.