### PR TITLE
Prefer systemd to timed

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,8 +15,7 @@ include(ECMFindQmlModule)
 include(AsteroidCMakeSettings)
 include(AsteroidTranslations)
 
-find_package(Qt5 COMPONENTS DBus REQUIRED)
-find_package(Timed REQUIRED)
+find_package(Qt5 COMPONENTS Core DBus REQUIRED)
 find_package(QtMpris REQUIRED)
 find_package(SystemSettings REQUIRED)
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -5,6 +5,7 @@ set(SRC
 	mediaservice.cpp
 	batteryservice.cpp
 	screenshotservice.cpp
+	settime.cpp
 	timeservice.cpp
 	service.cpp
 	characteristic.cpp
@@ -21,6 +22,7 @@ set(HEADERS
 	mediaservice.h
 	batteryservice.h
 	screenshotservice.h
+	settime.h
 	timeservice.h
 	service.h
 	characteristic.h
@@ -37,8 +39,8 @@ set(HEADERS
 add_executable(asteroid-btsyncd ${SRC} ${HEADERS})
 
 target_link_libraries(asteroid-btsyncd PRIVATE
+	Qt5::Core
 	Qt5::DBus
-	Timed::Timed
 	QtMpris::QtMpris
 	SystemSettings::SystemSettings
 	PkgConfig::GIOMM)

--- a/src/cts.cpp
+++ b/src/cts.cpp
@@ -7,9 +7,7 @@
 #include <QDateTime>
 #include <QTimeZone>
 
-#include <timed-qt5/wallclock>
-#include <timed-qt5/interface>
-
+#include "settime.h"
 #include "common.h"
 
 CTS::CTS() {
@@ -76,13 +74,9 @@ void CTS::parseCurrentTime(QByteArray& bytes)
     uint8_t exact_time_256 = bytes[8];
     uint8_t adjust_reason = bytes[9];
 
-    Maemo::Timed::WallClock::Settings s;
     QDateTime newTime(QDate(year, month, day), QTime(hour, minute, second));
     newTime.setTimeZone(QTimeZone::systemTimeZone());
-    s.setTimeManual(newTime.toTime_t());
-
-    Maemo::Timed::Interface timed;
-    timed.wall_clock_settings_async(s);
+    setSystemTime(newTime);
 }
 
 void CTS::TimeCharacteristicPropertiesChanged(QString /* interfaceName */,

--- a/src/settime.cpp
+++ b/src/settime.cpp
@@ -1,0 +1,29 @@
+#include <QDateTime>
+#include <QDBusInterface>
+#include <QDBusMessage>
+#include <QDebug>
+#include "settime.h"
+
+bool setSystemTime(const QDateTime& dateTime) {
+    QDBusInterface interface("org.freedesktop.timedate1",
+                             "/org/freedesktop/timedate1",
+                             "org.freedesktop.timedate1",
+                             QDBusConnection::systemBus());
+
+    const QDateTime utcDateTime = dateTime.toUTC();
+
+    const qint64 usec_utc{utcDateTime.toSecsSinceEpoch() * 1'000'000};
+
+    constexpr bool isAdmin{false};
+    constexpr bool adjustNTP{false};
+
+    QDBusMessage reply = interface.call("SetTime", usec_utc, isAdmin, adjustNTP);
+
+    if (reply.type() == QDBusMessage::ErrorMessage) {
+        qWarning("Failed to set time: %s", reply.errorMessage().toLocal8Bit().constData());
+        return false;
+    }
+
+    return true;
+}
+

--- a/src/settime.cpp
+++ b/src/settime.cpp
@@ -1,3 +1,20 @@
+/*
+ * Copyright (C) 2026 - Ed Beroset <beroset@ieee.org>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
 #include <QDateTime>
 #include <QDBusInterface>
 #include <QDBusMessage>

--- a/src/settime.h
+++ b/src/settime.h
@@ -1,0 +1,21 @@
+/*
+ * Copyright (C) 2026 - Florent Revest <revestflo@gmail.com>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef SETTIME_H
+#define SETTIME_H
+bool setSystemTime(const QDateTime& dateTime);
+#endif // SETTIME_H

--- a/src/settime.h
+++ b/src/settime.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2026 - Florent Revest <revestflo@gmail.com>
+ * Copyright (C) 2026 - Ed Beroset <beroset@ieee.org>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/timeservice.cpp
+++ b/src/timeservice.cpp
@@ -20,9 +20,7 @@
 #include <QDateTime>
 #include <QTimeZone>
 
-#include <timed-qt5/wallclock>
-#include <timed-qt5/interface>
-
+#include "settime.h"
 #include "timeservice.h"
 #include "characteristic.h"
 #include "common.h"
@@ -36,13 +34,9 @@ void TimeSetChrc::WriteValue(QByteArray value, QVariantMap)
     int minute = (unsigned char) value[4];
     int second = (unsigned char) value[5];
 
-    Maemo::Timed::WallClock::Settings s;
     QDateTime newTime(QDate(year, month, day), QTime(hour, minute, second));
     newTime.setTimeZone(QTimeZone::systemTimeZone());
-    s.setTimeManual(newTime.toTime_t());
-
-    Maemo::Timed::Interface timed;
-    timed.wall_clock_settings_async(s);
+    setSystemTime(newTime);
 }
 
 TimeService::TimeService(int index, QDBusConnection bus, QObject *parent) : Service(bus, index, TIME_UUID, parent)


### PR DESCRIPTION
This modifies asteroid-btsyncd to use systemd rather than timed.  It addresses on part of https://github.com/AsteroidOS/asteroid/issues/332