### PR TITLE
fix(cmake): use the correct AmberMpris name

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,7 +21,7 @@ find_package(Qt6 REQUIRED COMPONENTS Core DBus)
 find_package(SystemSettings REQUIRED)
 
 find_package(PkgConfig REQUIRED)
-pkg_check_modules(AmberMpris ambermpris6 REQUIRED IMPORTED_TARGET)
+pkg_check_modules(AmberMpris ambermpris REQUIRED IMPORTED_TARGET)
 pkg_check_modules(GIOMM giomm-2.4 REQUIRED IMPORTED_TARGET)
 set_property(GLOBAL APPEND PROPERTY _CMAKE_giomm-2.4_TYPE REQUIRED)
 


### PR DESCRIPTION
The file is ambermpris.pc, not ambermpris6.pc