### PR TITLE
battery: read level from MCE directly, drop SystemSettings dependency

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,7 +18,6 @@ include(Asteroid6CMakeSettings)
 include(Asteroid6Translations)
 
 find_package(Qt6 REQUIRED COMPONENTS Core DBus)
-find_package(SystemSettings REQUIRED)
 
 find_package(PkgConfig REQUIRED)
 pkg_check_modules(AmberMpris ambermpris6 REQUIRED IMPORTED_TARGET)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -5,6 +5,7 @@ set(
 	weatherservice.cpp
 	mediaservice.cpp
 	batteryservice.cpp
+	batterystatus.cpp
 	screenshotservice.cpp
 	settime.cpp
 	timeservice.cpp
@@ -24,6 +25,7 @@ set(
 	weatherservice.h
 	mediaservice.h
 	batteryservice.h
+	batterystatus.h
 	screenshotservice.h
 	settime.h
 	timeservice.h
@@ -48,7 +50,6 @@ target_link_libraries(
 		Qt6::Core
 		Qt6::DBus
 		PkgConfig::AmberMpris
-		SystemSettings::SystemSettings
 		PkgConfig::GIOMM
 )
 

--- a/src/batteryservice.cpp
+++ b/src/batteryservice.cpp
@@ -15,7 +15,7 @@
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
 
-#include <batterystatus.h>
+#include "batterystatus.h"
 
 #include <QTimer>
 #include <QDBusMessage>

--- a/src/batterystatus.cpp
+++ b/src/batterystatus.cpp
@@ -1,0 +1,59 @@
+/*
+ * Copyright (C) 2026 - Florent Revest <revestflo@gmail.com>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "batterystatus.h"
+
+#include <QDBusConnection>
+#include <QDBusInterface>
+#include <QDBusPendingCall>
+#include <QDBusPendingCallWatcher>
+#include <QDBusPendingReply>
+
+static const char *MCE_SERVICE          = "com.nokia.mce";
+static const char *MCE_REQUEST_PATH     = "/com/nokia/mce/request";
+static const char *MCE_REQUEST_IF       = "com.nokia.mce.request";
+static const char *MCE_SIGNAL_PATH      = "/com/nokia/mce/signal";
+static const char *MCE_SIGNAL_IF        = "com.nokia.mce.signal";
+static const char *MCE_BATTERY_LEVEL_GET = "get_battery_level";
+static const char *MCE_BATTERY_LEVEL_SIG = "battery_level_ind";
+
+BatteryStatus::BatteryStatus(QObject *parent) : QObject(parent)
+{
+    QDBusConnection::systemBus().connect(
+        MCE_SERVICE, MCE_SIGNAL_PATH, MCE_SIGNAL_IF, MCE_BATTERY_LEVEL_SIG,
+        this, SLOT(onBatteryLevelInd(int)));
+
+    QDBusInterface mce(MCE_SERVICE, MCE_REQUEST_PATH, MCE_REQUEST_IF,
+                       QDBusConnection::systemBus());
+    QDBusPendingCall call = mce.asyncCall(MCE_BATTERY_LEVEL_GET);
+    auto *watcher = new QDBusPendingCallWatcher(call, this);
+    connect(watcher, &QDBusPendingCallWatcher::finished, this,
+            [this](QDBusPendingCallWatcher *w) {
+        QDBusPendingReply<int> reply = *w;
+        w->deleteLater();
+        if (!reply.isError())
+            onBatteryLevelInd(reply.value());
+    });
+}
+
+void BatteryStatus::onBatteryLevelInd(int percentage)
+{
+    if (percentage != m_chargePercentage) {
+        m_chargePercentage = percentage;
+        emit chargePercentageChanged(percentage);
+    }
+}

--- a/src/batterystatus.h
+++ b/src/batterystatus.h
@@ -1,0 +1,41 @@
+/*
+ * Copyright (C) 2026 - Florent Revest <revestflo@gmail.com>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef BATTERYSTATUS_H
+#define BATTERYSTATUS_H
+
+#include <QObject>
+
+class BatteryStatus : public QObject
+{
+    Q_OBJECT
+public:
+    explicit BatteryStatus(QObject *parent = nullptr);
+
+    int chargePercentage() const { return m_chargePercentage; }
+
+signals:
+    void chargePercentageChanged(int percentage);
+
+private slots:
+    void onBatteryLevelInd(int percentage);
+
+private:
+    int m_chargePercentage = -1;
+};
+
+#endif // BATTERYSTATUS_H


### PR DESCRIPTION
nemo-qml-plugin-systemsettings was pulled in solely for its BatteryStatus class, of which btsyncd uses only chargePercentage. Replace it with a ~50-line MCE-backed reader (get_battery_level + battery_level_ind) and drop the find_package(SystemSettings)/link.